### PR TITLE
fix plugin name so that entry point symbol matches library name

### DIFF
--- a/src/gstlibde265.c
+++ b/src/gstlibde265.c
@@ -61,9 +61,9 @@ plugin_init (GstPlugin * plugin)
 
 GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR,
 #if GST_CHECK_VERSION(1,0,0)
-    gstlibde265,
+    libde265,
 #else
-    "gstlibde265",
+    "libde265",
 #endif
     "HEVC/H.265 decoder using libde265", plugin_init, VERSION, "LGPL",
 #if GST_CHECK_VERSION(1,0,0)


### PR DESCRIPTION
When the plugin is loaded, the entry point `gst_plugin_libde265_get_desc` is required.
However, the old symbol name was `gst_plugin_gstlibde265_get_desc`, preventing the plugin from being loaded.
